### PR TITLE
Harvest: temporarily set mp70 devices as 'other' until sss is updated…

### DIFF
--- a/tracking/harvest.py
+++ b/tracking/harvest.py
@@ -363,7 +363,7 @@ def save_mp70(dimap, queueitem):
         sbd["TU"] = time.mktime(datetime.strptime(sbd["RAW"][6], "%m/%d/%Y %H:%M:%S").timetuple())
         sbd["VL"] = int(sbd["RAW"][4])
         sbd["DR"] = int(sbd["RAW"][5])
-        sbd["TY"] = 'mp70'
+        sbd["TY"] = 'other'
     except ValueError as e:
         LOGGER.error(e)
         dimap.flag(msgid)


### PR DESCRIPTION
… to include mp70 in DBCA filter

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dbca-wa/resource_tracking/85)
<!-- Reviewable:end -->
